### PR TITLE
Use `doc = include_str!` instead of `doc(include`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,7 @@ jobs:
         rust-toolchains:
           - 1.42.0
           - stable
+          - nightly
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -59,13 +60,18 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
-      - name: Cargo test (no UI)
+      - name: Cargo +nightly test (no UI)
+        if: matrix.rust-toolchains == 'nightly'
         uses: actions-rs/cargo@v1
-        env:
-          RUSTC_BOOTSTRAP: "1"
         with:
           command: test
           args: --features nightly
+
+      - name: Cargo test (no UI)
+        if: matrix.rust-toolchains != 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
 
   # == UI TESTS ==
   ui-test:

--- a/.github/workflows/future-proof.yml
+++ b/.github/workflows/future-proof.yml
@@ -35,10 +35,15 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v2
 
-      - name: Cargo test (no UI)
+      - name: Cargo +nightly test (no UI)
+        if: matrix.rust-toolchains == 'nightly'
         uses: actions-rs/cargo@v1
-        env:
-          RUSTC_BOOTSTRAP: "1"
         with:
           command: test
           args: --features nightly
+
+      - name: Cargo test (no UI)
+        if: matrix.rust-toolchains != 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,5 +104,7 @@ impl<State, try_eval> RunnerWithTryEval<State, try_eval> {
 }
 
 #[cfg(all(doc, feature = "nightly"))]
-#[doc(include = "compile_fail_tests.md")]
+#[cfg_attr(all(doc, feature = "nightly"),
+    cfg_attr(all(), doc = include_str!("compile_fail_tests.md")),
+)]
 mod compile_fail_tests {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "nightly",
-    feature(external_doc),
-    doc(include = "../README.md")
+    cfg_attr(all(), doc = include_str!("../README.md")),
 )]
 #![allow(nonstandard_style)]
 


### PR DESCRIPTION
This fixes CI breakage on nightly due to the latter having been removed.